### PR TITLE
Added ifup can0 to the init file for the v6x

### DIFF
--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -38,3 +38,6 @@ if ver hwbasecmp 00a 008
 then
 	mcp23009 start -b 3 -X -D 0xf1 -O 0xf0 -P 0x0f -U 10
 fi
+
+# Auto start can0 device
+ifup can0


### PR DESCRIPTION
Added the startup for the can0 device. Now it starts automatically instead of having to enable it manually.